### PR TITLE
fix: Use token instead of ssh keys to push tags

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -14,16 +14,14 @@ jobs:
       - name: Check out
         uses: actions/checkout@v4
         with:
-          ssh-key: ${{ secrets.COMMITIZEN_PRIVATE_KEY }}
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           fetch-depth: 0
       - name: Create bump and changelog
         uses: commitizen-tools/commitizen-action@master
         with:
-          github_token: ${{ secrets.COMMITIZEN_PRIVATE_KEY }}
+          github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           changelog_increment_filename: body.md
-          push: false
-      - name: Push using ssh
-        run: git push origin main --tags
+          push: true
       - name: Release
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -119,7 +119,7 @@ jobs:
         run: |
           python -m pip install build
           python -m build --wheel --sdist --outdir dist
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: wheels
           path: dist/*


### PR DESCRIPTION
## Issue

- SSH keys are not the preferred method to give write access to github actions.

## Changes

- Use token instead of ssh keys to push tags.
