### PR TITLE
fix: Use uv provider from commitizen

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,5 +75,5 @@ disallow_incomplete_defs = true
 
 [tool.commitizen]
 version_scheme = "semver"
-version_provider = "pep621"
+version_provider = "uv"
 update_changelog_on_bump = true


### PR DESCRIPTION
## Issue

- Each version bump ignored `uv.lock` file.

## Changes

- Use `uv` provider. https://github.com/commitizen-tools/commitizen/pull/1351
