### PR TITLE
fix: Update download-artifact action version

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -135,7 +135,7 @@ jobs:
       id-token: write
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: wheels
           path: dist


### PR DESCRIPTION
## Issue

- https://github.com/khrapovs/OrderBookMatchingEngine/actions/runs/13590654921/job/37995772218

## Changes

- Update download-artifact action version to v4
